### PR TITLE
feat/ENG_153 custom providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## 0.2.0
+### Added
+- Extensible provider system. Providers can now be supplied in multiple ways:
+  - As config mapping `{ name: { apiKey: "..." } }` (existing behavior).
+  - As ready-made instances:  
+    ```ts
+    { 
+      stripe: new StripeProvider({ apiKey: "..." }), 
+      custom: new MyProvider({ apiKey: "..." }) 
+    }
+    ```
+  - As a list of instances:  
+    ```ts
+    [
+      new WalleotProvider({ apiKey: "..." }), 
+      new MyProvider({ apiKey: "..." })
+    ]
+    ```

--- a/README.md
+++ b/README.md
@@ -124,6 +124,44 @@ Start your MCP transport (stdio / http / ws) as usual. Any MCP client that conne
 
 ---
 
+## Providers: alternative styles (optional)
+
+**Instances instead of config (advanced):**
+```ts
+import { installPayMCP, PaymentFlow } from "paymcp";
+import { WalleotProvider, CoinbaseProvider } from "paymcp/providers";
+
+installPayMCP(server, {
+  providers: [
+    new WalleotProvider({ apiKey: process.env.WALLEOT_API_KEY ?? "" }),
+    new CoinbaseProvider({ apiKey: process.env.COINBASE_COMMERCE_API_KEY ?? "" }),
+  ],
+  paymentFlow: PaymentFlow.TWO_STEP,
+});
+// Note: right now the first configured provider is used.
+```
+
+**Custom provider (minimal):**  
+Any provider must implement `createPayment(...)` and `getPaymentStatus(...)`.
+```ts
+import type { BasePaymentProvider } from "paymcp/providers";
+
+class MyProvider implements BasePaymentProvider {
+  constructor(private opts: { apiKey: string }) {}
+
+  async createPayment(amount: number, currency: string, description: string) {
+    // return { paymentId, paymentUrl }
+    return { paymentId: "demo-1", paymentUrl: "https://example.com/pay" };
+  }
+
+  async getPaymentStatus(paymentId: string) {
+    return "paid";
+  }
+}
+
+installPayMCP(server, { providers: [ new MyProvider({ apiKey: "..." }) ] });
+```
+
 ## 🧩 Supported Providers
 
 - ✅ [Adyen](https://www.adyen.com)
@@ -153,7 +191,7 @@ interface PaymentProvider {
 }
 ```
 
-See `src/providers/walleot.ts` and `src/providers/stripe.ts` for examples. Add yours, export it from the provider map, and pass config to `installPayMCP()`.
+See `src/providers/walleot.ts` and `src/providers/stripe.ts` for examples. Add yours and either pass an **instance directly** (recommended), or export it in the provider map and pass config to `installPayMCP()`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paymcp",
-  "version": "0.0.9",
+  "version": "0.2.0",
   "description": "Provider-agnostic payment layer for MCP (Model Context Protocol) tools and agents.",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -8,15 +8,21 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./providers": {
+      "types": "./dist/providers/index.d.ts",
+      "import": "./dist/providers/index.js",
+      "require": "./dist/providers/index.cjs"
     }
   },
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean --sourcemap",
+    "build": "tsup src/index.ts src/providers/index.ts --format cjs,esm --dts --clean --sourcemap",
     "watch": "npm run build -- --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/core/PayMCP.ts
+++ b/src/core/PayMCP.ts
@@ -2,8 +2,11 @@ import { PayMCPOptions, PayToolConfig } from "../types/config.js";
 import { McpServerLike } from "../types/mcp.js";
 import { PaymentFlow } from "../types/payment.js";
 import { buildProviders, ProviderInstances } from "../providers/index.js";
+import type { ProviderConfig, BasePaymentProvider } from "../providers/index.js";
 import { appendPriceToDescription } from "../utils/messages.js";
 import { makeFlow } from "../flows/index.js";
+
+type ProvidersInput = ProviderConfig | BasePaymentProvider[];
 
 export class PayMCP {
     private server: McpServerLike;
@@ -15,7 +18,7 @@ export class PayMCP {
 
     constructor(server: McpServerLike, opts: PayMCPOptions) {
         this.server = server;
-        this.providers = buildProviders(opts.providers as any);//TODO
+        this.providers = buildProviders(opts.providers as ProvidersInput);
         this.flow = opts.paymentFlow ?? PaymentFlow.TWO_STEP;
         this.wrapperFactory = makeFlow(this.flow);
         this.originalRegisterTool = server.registerTool.bind(server);

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -7,11 +7,12 @@ import { type Logger } from "../types/logger.js";
 import { AdyenProvider } from "./adyen.js";
 import { CoinbaseProvider } from "./coinbase.js";
 
+export { WalleotProvider, StripeProvider, PayPalProvider, SquareProvider, AdyenProvider, CoinbaseProvider };
+export type { BasePaymentProvider };
+
+type ProviderCtor = new (opts: any) => BasePaymentProvider;
 /** Registry of known providers. */
-const PROVIDER_MAP: Record<
-  string,
-  new (opts: { apiKey: string; logger?: Logger, successUrl?:string, sandbox?: boolean, merchantAccount?:string }) => BasePaymentProvider
-> = {
+const PROVIDER_MAP: Record<string, ProviderCtor> = {
   stripe: StripeProvider,
   walleot: WalleotProvider,
   paypal: PayPalProvider,
@@ -20,23 +21,69 @@ const PROVIDER_MAP: Record<
   coinbase: CoinbaseProvider
 };
 
+function isProvider(x: unknown): x is BasePaymentProvider {
+  return !!x && typeof (x as any).createPayment === "function" && typeof (x as any).getPaymentStatus === "function";
+}
+
+function keyFor(inst: any, fallback?: string): string {
+  const name = (inst as any)?.slug ?? (inst as any)?.name ?? (inst as any)?.constructor?.name ?? fallback ?? "provider";
+  return String(name).toLowerCase();
+}
+
+/** Allow advanced users/plugins to register additional provider classes at runtime. */
+export function registerProvider(name: string, ctor: ProviderCtor): void {
+  if (!name || typeof name !== "string") {
+    throw new Error("[PayMCP] registerProvider: name must be a non-empty string");
+  }
+  PROVIDER_MAP[name.toLowerCase()] = ctor;
+}
+
+export type ProviderConfig = Record<
+  string,
+  BasePaymentProvider | { apiKey: string; successUrl?: string; cancelUrl?: string; merchantAccount?: string; sandbox?: boolean; logger?: Logger }
+>;
+
 export type ProviderInstances = Record<string, BasePaymentProvider>;
 
 /**
- * Converts an object of the form
- *   { "stripe": { apiKey: "..." }, "walleot": { apiKey: "..." } }
- * into { "stripe": StripeProviderInstance, "walleot": WalleotProviderInstance }.
+ * Normalize providers into a map name -> instance.
+ * Accepts either a mapping of names to options/instances, or an array of instances.
  */
 export function buildProviders(
-  config: Record<string, { apiKey: string; successUrl?: string; cancelUrl?: string; merchantAccount?:string; logger?: Logger }>
+  configOrInstances: ProviderConfig | BasePaymentProvider[]
 ): ProviderInstances {
   const instances: ProviderInstances = {};
-  for (const [name, opts] of Object.entries(config)) {
-    const cls = PROVIDER_MAP[name.toLowerCase()];
-    if (!cls) {
+
+  // Case A: iterable of instances
+  if (Array.isArray(configOrInstances)) {
+    for (const inst of configOrInstances) {
+      if (!isProvider(inst)) {
+        throw new Error("[PayMCP] buildProviders: iterable contains a non-provider instance");
+      }
+      const key = keyFor(inst);
+      instances[key] = inst;
+    }
+    return instances;
+  }
+
+  // Case B: mapping name -> options or instance
+  for (const [name, value] of Object.entries(configOrInstances)) {
+    if (isProvider(value)) {
+      const key = name || keyFor(value);
+      instances[key] = value;
+      continue;
+    }
+
+    const ctor = PROVIDER_MAP[name.toLowerCase()];
+    if (!ctor) {
       throw new Error(`[PayMCP] Unknown provider: ${name}`);
     }
-    instances[name] = new cls(opts);
+    const obj = new ctor(value as any);
+    if (!isProvider(obj)) {
+      throw new Error(`[PayMCP] Constructed provider for '${name}' does not implement required methods`);
+    }
+    instances[name] = obj;
   }
+
   return instances;
 }


### PR DESCRIPTION
- Extensible provider system. Providers can now be supplied in multiple ways:
  - As config mapping `{ name: { apiKey: "..." } }` (existing behavior).
  - As ready-made instances:  
    ```ts
    { 
      stripe: new StripeProvider({ apiKey: "..." }), 
      custom: new MyProvider({ apiKey: "..." }) 
    }
    ```
  - As a list of instances:  
    ```ts
    [
      new WalleotProvider({ apiKey: "..." }), 
      new MyProvider({ apiKey: "..." })
    ]
    ```